### PR TITLE
fix version

### DIFF
--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     yandex = {
-      source = "yandex-cloud/yandex"
+      source  = "yandex-cloud/yandex"
+      version = ">= 0.72.0"
     }
   }
   required_version = ">= 1.3"

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     yandex = {
-      source = "yandex-cloud/yandex"
+      source  = "yandex-cloud/yandex"
+      version = ">= 0.72.0"
     }
   }
   required_version = ">= 1.3"


### PR DESCRIPTION
```
Warning: Missing version constraint for provider "yandex" in `required_providers` (terraform_required_providers)

  on versions.tf line 3:
   3:     yandex = {
   4:       source = "yandex-cloud/yandex"
   5:     }

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.12.0/docs/rules/terraform_required_providers.md

```